### PR TITLE
Allow SageMaker Batch instance type to be customised input

### DIFF
--- a/transcript-orchestration/package-lock.json
+++ b/transcript-orchestration/package-lock.json
@@ -6721,9 +6721,9 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.0.tgz",
-      "integrity": "sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -9189,9 +9189,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -14864,9 +14864,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.0.tgz",
-      "integrity": "sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -16524,9 +16524,9 @@
       }
     },
     "undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "requires": {
         "busboy": "^1.6.0"
       }

--- a/transcript-orchestration/statemachine/transcription-step-function.asl.json
+++ b/transcript-orchestration/statemachine/transcription-step-function.asl.json
@@ -10,7 +10,8 @@
         "forceTranscribe": false,
         "forceWhisper": false,
         "createPR": true,
-        "bucketName": "${BucketName}"
+        "bucketName": "${BucketName}",
+        "instanceType": "ml.m4.xlarge"
       }
     },
     "ApplyDefaults": {
@@ -143,7 +144,7 @@
                 },
                 "TransformResources": {
                   "InstanceCount": 1,
-                  "InstanceType": "ml.m4.xlarge"
+                  "InstanceType.$": "$.inputs.instanceType"
                 }
               },
               "Next": "Copy Whisper Transcript"


### PR DESCRIPTION
Allow SageMaker Batch instance type to be overridden in the Step Function input.

## Motivation
A 50 minute MP3 failed to be transformed. The SageMaker transform job stopped with an error after around 54 minutes. There was no clear error in the logs and no available CPU/Memory metrics. This override was tried and, using an `ml.m5.4xlarge`, execution completed successfully in 25 minutes.

Example state machine input:
```
{
  "audioInputKey": ...,
  "instanceType": "ml.m5.4xlarge"
}
```

