### PR TITLE
Update whisper with PyPI module

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can deploy this complete application to your own AWS account.
    cd whisper-image
 
    # Build the container image
-   docker build -t $REPOSITORY_URI .
+   docker build --platform linux/amd64 -t $REPOSITORY_URI .
 
    # Log in to ECR with Docker (make sure to set AWS_REGION and AWS_ACCCOUNT_ID)
    aws ecr get-login-password | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com

--- a/whisper-image/Dockerfile
+++ b/whisper-image/Dockerfile
@@ -1,8 +1,9 @@
 ARG TARGETPLATFORM=linux/amd64
-FROM nvidia/cuda:11.6.0-base-ubuntu20.04
+ARG TARGETARCH=amd64
+FROM nvidia/cuda:12.2.2-base-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=Etc/UTC 
+ENV TZ=Etc/UTC
 
 RUN apt-get -qq update && apt-get install -qq --no-install-recommends \
          wget \
@@ -10,11 +11,7 @@ RUN apt-get -qq update && apt-get install -qq --no-install-recommends \
          python3-setuptools \
          nginx \
          ffmpeg \
-         git \
-         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-
-# RUN pip --no-cache-dir install numpy==1.16.2 scipy==1.2.1 scikit-learn==0.20.2 pandas flask gunicorn
 
 # Set some environment variables. PYTHONUNBUFFERED keeps Python from buffering our standard
 # output stream, which means that logs can be delivered to the user quickly. PYTHONDONTWRITEBYTECODE
@@ -25,7 +22,6 @@ ENV PYTHONDONTWRITEBYTECODE=TRUE
 ENV PATH="/app:${PATH}"
 RUN mkdir /app
 WORKDIR /app
-RUN pip install git+https://github.com/openai/whisper.git
 COPY requirements.txt /app
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 COPY app /app

--- a/whisper-image/requirements.txt
+++ b/whisper-image/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.24.96
-flask
-gunicorn
+Flask==2.2.2
+gunicorn==20.1.0
+openai-whisper==20230918


### PR DESCRIPTION
Prompted by the following failure when running whisper from the previous, GitHub-installed Whisper module:
```
RuntimeError: Model has been downloaded but the SHA256 checksum does not not match. Please retry loading the model.
```
Whisper can now be installed from PyPI, so the build process has been updated. The SHA256 error is no longer appearing.