### PR TITLE
fix: migrate to sonnet 4.6 inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,12 @@ __pycache__/
 # other
 TODO.txt
 .tmp/
+
+.DS_Store
+.aws-sam/
+.codex/
+.ipynb_checkpoints/
+.local.env.json
+AGENTS.md
+samconfig.toml
+

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ export default defineConfig({
     maxSpeakers: 4,
   },
   llmRefinement: {
-    bedrockInferenceProfileId: 'eu.anthropic.claude-sonnet-4-20250514-v1:0',
+    bedrockInferenceProfileId: 'eu.anthropic.claude-sonnet-4-6',
     additionalContext: 'This is a tech podcast about AWS and serverless.',
   },
   captions: {
@@ -299,7 +299,7 @@ Array of replacement rules, each with:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `bedrockInferenceProfileId` | string | required | Bedrock inference profile (e.g., `"eu.anthropic.claude-sonnet-4-20250514-v1:0"`) |
+| `bedrockInferenceProfileId` | string | required | Bedrock inference profile (e.g., `"eu.anthropic.claude-sonnet-4-6"`) |
 | `additionalContext` | string | - | Context to help the LLM understand domain-specific terms |
 | `modelConfig.max_tokens` | number | `64000` | Maximum tokens in response |
 | `modelConfig.temperature` | number | `0.2` | Model temperature |

--- a/cdk/config.example.ts
+++ b/cdk/config.example.ts
@@ -82,7 +82,7 @@ export default defineConfig({
     },
   ],
   llmRefinement: {
-    bedrockInferenceProfileId: 'eu.anthropic.claude-sonnet-4-20250514-v1:0',
+    bedrockInferenceProfileId: 'eu.anthropic.claude-sonnet-4-6',
     modelConfig: {
       temperature: 0.8,
     },

--- a/cdk/lib/podwhisperer-stack.ts
+++ b/cdk/lib/podwhisperer-stack.ts
@@ -152,7 +152,7 @@ export class PodwhispererStack extends cdk.Stack {
     bucket.grantReadWrite(pipelineLambda, 'output/*')
 
     // Grant Bedrock permissions if LLM refinement is configured
-    // For cross-region inference profiles (e.g., eu.anthropic.claude-sonnet-4-20250514-v1:0),
+    // For cross-region inference profiles (e.g., eu.anthropic.claude-sonnet-4-6),
     // we need permissions on both the inference profile and the underlying foundation model.
     // The geographic prefix (eu., us., apac., global.) is stripped to get the foundation model ID.
     if (pipelineConfig.llmRefinement?.bedrockInferenceProfileId) {

--- a/lambdas/pipeline/steps/llm-refinement.test.ts
+++ b/lambdas/pipeline/steps/llm-refinement.test.ts
@@ -550,7 +550,7 @@ describe('llmRefinement integration', () => {
   }
 
   const defaultConfig = {
-    bedrockModelId: 'test-model',
+    bedrockInferenceProfileId: 'test-model',
     modelConfig: { max_tokens: 64000, temperature: 0.3 },
   }
 
@@ -803,7 +803,7 @@ describe('llmRefinement integration', () => {
     }
 
     const config = {
-      bedrockModelId: 'test-model',
+      bedrockInferenceProfileId: 'test-model',
       additionalContext: 'This is a podcast about parenting in Boston.',
       modelConfig: { max_tokens: 64000, temperature: 0.3 },
     }
@@ -816,6 +816,27 @@ describe('llmRefinement integration', () => {
     const promptText = body.messages[0].content[0].text
     expect(promptText).toContain('This is a podcast about parenting in Boston.')
     expect(promptText).toContain('## Additional Context')
+  })
+
+  it('adds remediation context for Bedrock legacy model access errors', async () => {
+    const legacyError = new Error(
+      'Access denied. This Model is marked by provider as Legacy and you have not been actively using the model in the last 30 days. Please upgrade to an active model on Amazon Bedrock',
+    )
+    const mockClient = {
+      send: vi.fn().mockRejectedValue(legacyError),
+    } as unknown as BedrockRuntimeClient
+
+    const transcript = {
+      segments: [
+        { start: 0.0, end: 2.0, text: 'hello', speaker: 'SPEAKER_00' },
+      ],
+    }
+
+    await expect(
+      llmRefinement(transcript, defaultConfig, mockClient),
+    ).rejects.toThrow(
+      'Update llmRefinement.bedrockInferenceProfileId to an active Bedrock inference profile',
+    )
   })
 
   it('does not include additional context section when not provided', async () => {
@@ -984,7 +1005,13 @@ describe('llmRefinement integration', () => {
 
     const configWithDisabledValidation = {
       ...defaultConfig,
-      suggestionValidation: { enabled: false },
+      suggestionValidation: {
+        enabled: false,
+        maxWordChangeRatio: 0.4,
+        maxNormalizedEditDistance: 0.5,
+        maxConsecutiveChanges: 3,
+        minWordsForRatioCheck: 5,
+      },
     }
 
     const stats = await llmRefinement(

--- a/lambdas/pipeline/steps/llm-refinement.ts
+++ b/lambdas/pipeline/steps/llm-refinement.ts
@@ -13,6 +13,7 @@ corrected words, then intelligently merges/splits timing data.
 import {
   type BedrockRuntimeClient,
   InvokeModelCommand,
+  type InvokeModelCommandOutput,
 } from '@aws-sdk/client-bedrock-runtime'
 import type { LlmRefinementConfig } from '@podwhisperer/config'
 import type {
@@ -34,6 +35,33 @@ import {
 
 // Re-export for test compatibility
 export { reconcileSegment, reconstructText, textToWords }
+
+const ACTIVE_BEDROCK_INFERENCE_PROFILE_EXAMPLE =
+  'eu.anthropic.claude-sonnet-4-6'
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+function isLegacyModelAccessDenied(error: unknown): boolean {
+  const message = getErrorMessage(error)
+  return (
+    /access\s*denied/i.test(message) &&
+    /marked by provider as Legacy/i.test(message) &&
+    /upgrade to an active model/i.test(message)
+  )
+}
+
+function createLegacyModelError(profileId: string, error: unknown): Error {
+  return new Error(
+    `Bedrock denied invocation for "${profileId}" because the provider marked the model as legacy. ` +
+      `Update llmRefinement.bedrockInferenceProfileId to an active Bedrock inference profile, ` +
+      `for example "${ACTIVE_BEDROCK_INFERENCE_PROFILE_EXAMPLE}", then redeploy the CDK stack. ` +
+      `Original Bedrock error: ${getErrorMessage(error)}`,
+    { cause: error },
+  )
+}
 
 const REFINEMENT_PROMPT_TEMPLATE = `You are a transcript editor. Your task is to fix ONLY obvious transcription errors - words that were clearly misheard or misspelled by the speech-to-text system.
 
@@ -162,7 +190,15 @@ export async function llmRefinement(
   })
 
   const startTime = Date.now()
-  const modelResponse = await bedrockClient.send(invokeCommand)
+  let modelResponse: InvokeModelCommandOutput
+  try {
+    modelResponse = await bedrockClient.send(invokeCommand)
+  } catch (error) {
+    if (isLegacyModelAccessDenied(error)) {
+      throw createLegacyModelError(config.bedrockInferenceProfileId, error)
+    }
+    throw error
+  }
   stats.llmResponseTimeMs = Date.now() - startTime
 
   const raw = await modelResponse.body.transformToString('utf8')

--- a/lambdas/pipeline/utils/bedrock.ts
+++ b/lambdas/pipeline/utils/bedrock.ts
@@ -5,11 +5,11 @@
 /**
  * Maps a Bedrock inference profile ID prefix to an AWS region.
  *
- * @param profileId - The Bedrock inference profile ID (e.g., "eu.anthropic.claude-sonnet-4-20250514-v1:0")
+ * @param profileId - The Bedrock inference profile ID (e.g., "eu.anthropic.claude-sonnet-4-6")
  * @returns The AWS region to use for the Bedrock client
  *
  * @example
- * getRegionFromProfileId("eu.anthropic.claude-sonnet-4-20250514-v1:0")
+ * getRegionFromProfileId("eu.anthropic.claude-sonnet-4-6")
  * // => "eu-west-1"
  *
  * getRegionFromProfileId("us.anthropic.claude-3-haiku-20240307-v1:0")

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -58,7 +58,7 @@ export type SuggestionValidationConfig = z.infer<
 export const LlmRefinementConfigSchema = z.object({
   /** Optional additional context to help the LLM understand domain-specific terms */
   additionalContext: z.string().optional(),
-  /** The inference profile ID to use for refinement. Eg: "eu.anthropic.claude-sonnet-4-20250514-v1:0" */
+  /** The inference profile ID to use for refinement. Eg: "eu.anthropic.claude-sonnet-4-6" */
   bedrockInferenceProfileId: z.string(),
   /** Model configuration parameters for the Bedrock InvokeModel request */
   modelConfig: z


### PR DESCRIPTION
resolves
```
ResourceNotFoundException
Access denied. This Model is marked by provider as Legacy and you have not been actively using the model in the last 30 days. Please upgrade to an active model on Amazon Bedrock
```
in `llm-refinement` step of the durable exceution